### PR TITLE
Disable auto update checks

### DIFF
--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -297,7 +297,7 @@ impl IVerge {
             use_default_bypass: Some(true),
             proxy_guard_duration: Some(30),
             auto_close_connection: Some(true),
-            auto_check_update: Some(true),
+            auto_check_update: Some(false),
             enable_builtin_enhanced: Some(true),
             auto_log_clean: Some(3),
             webdav_url: None,

--- a/src/components/layout/update-button.tsx
+++ b/src/components/layout/update-button.tsx
@@ -18,7 +18,7 @@ export const UpdateButton = (props: Props) => {
   const viewerRef = useRef<DialogRef>(null);
 
   const { data: updateInfo } = useSWR(
-    auto_check_update || auto_check_update === null ? "checkUpdate" : null,
+    auto_check_update ? "checkUpdate" : null,
     check,
     {
       errorRetryCount: 2,

--- a/src/components/setting/mods/misc-viewer.tsx
+++ b/src/components/setting/mods/misc-viewer.tsx
@@ -23,7 +23,7 @@ export const MiscViewer = forwardRef<DialogRef>((props, ref) => {
   const [values, setValues] = useState({
     appLogLevel: "warn",
     autoCloseConnection: true,
-    autoCheckUpdate: true,
+    autoCheckUpdate: false,
     enableBuiltinEnhanced: true,
     proxyLayoutColumn: 6,
     defaultLatencyTest: "",
@@ -37,7 +37,7 @@ export const MiscViewer = forwardRef<DialogRef>((props, ref) => {
       setValues({
         appLogLevel: verge?.app_log_level ?? "warn",
         autoCloseConnection: verge?.auto_close_connection ?? true,
-        autoCheckUpdate: verge?.auto_check_update ?? true,
+        autoCheckUpdate: verge?.auto_check_update ?? false,
         enableBuiltinEnhanced: verge?.enable_builtin_enhanced ?? true,
         proxyLayoutColumn: verge?.proxy_layout_column || 6,
         defaultLatencyTest: verge?.default_latency_test || "",


### PR DESCRIPTION
## Summary
- turn off auto update checks by default
- let `UpdateButton` check updates only when auto check update is enabled
- disable Auto Check Update default value in settings

## Testing
- `pnpm format:check`
- `pnpm check` *(fails: Cannot find package 'tar')*
- `pnpm fmt` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68445661db3c8329a1511d2fd0da5d92